### PR TITLE
remove unused 'createValidationServer' function

### DIFF
--- a/lib/acme.js
+++ b/lib/acme.js
@@ -89,16 +89,6 @@ function createResponse(challenge) {
   return null;
 }
 
-function createValidationServer(domain, challenge, response) {
-  switch (challenge.type) {
-    case "simpleHttps":
-      return SimpleHttpsServer(domain, challenge, response);
-    case "dvsni":
-      return DvsniServer(domain, challenge, response);
-  }
-  return null;
-}
-
 function createValidationProcess(domain, type, challenge) {
   switch (type) {
     case "simpleHttps":


### PR DESCRIPTION
Not sure whether this function is planned to be used in the future, but when reading the (otherwise very readable and to-the-point) code, I found it confusing that this function is first defined and then later bypassed.

Removing it saves 10 lines of code. :)