### PR TITLE
Fix basic test

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -4,14 +4,14 @@ var request = require('supertest');
 var acme = require("../lib/acme");
 
 var server = acme.createServer();
-server.listen(5000);
+server.listen(4000);
 
 describe('verify demo works', function(){
   it('demo should return public and private keys', function(done){
     acme.enableLocalUsage();
 
-    var url = "http://localhost:5000/";
-    acme.getMeACertificate(url, "example.com", function(certJSON) {
+    var url = "https://localhost:4000/";
+    acme.getMeACertificate(url+"acme/new-authz", url+"acme/new-cert", "example.com", function(certJSON) {
       var cert = JSON.stringify(certJSON);
       assert.notInclude(cert, 'error');
       assert.include(cert, 'publicKey');


### PR DESCRIPTION
Localhost usage is hard-coded to port 4000, and fails if you use port 5000.

Also, the call to `getMeACertificate` was using the wrong arguments.